### PR TITLE
Use meta information in messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ String template is based on named arguments:
 ``` js
 '{level}' -> level of messages
 '{message}' -> text of messages
+'{meta}' -> meta object of messages
 ```
 
 Due applying some coding style, you must change these option properties if you're updating from lower versions to 1.0.0:
@@ -103,12 +104,12 @@ winston.add(winston.transports.Telegram, {
 		chatId : 'CHAT_ID',
 		level : 'error',
 		unique : true,
-		template : '[{level}] [{message}]'
+		template : '[{level}] [{message}] [{meta.property1}] [{meta.property2}]'
     });
 
-winston.log('error', 'Redrum. Redrum. Redrum.');
+winston.log('error', 'Redrum. Redrum. Redrum.', { property1: 'foo', property2: 'bar' });
 
-//Output: [error] [Redrum. Redrum. Redrum.]
+//Output: [error] [Redrum. Redrum. Redrum.] [foo] [bar]
 ```
 
 ## Change history

--- a/lib/winston-telegram.js
+++ b/lib/winston-telegram.js
@@ -8,6 +8,7 @@
 var util  = require('util');
 var request  = require('request');
 var winston  = require('winston');
+var format = require('sf');
 var nargs = /\{([0-9a-zA-Z_]+)\}/g;
 
 /**
@@ -65,7 +66,7 @@ Telegram.prototype.log = function (level, msg, meta, callback) {
     method : 'POST',
     json : {
       chat_id : this.chatId,
-      text : format(this.template,{level : level, message : msg}),
+      text : format(this.template,{level : level, message : msg, meta : meta}),
       disable_notification : this.disableNotification
     }
   }, function(error, response, body){
@@ -79,31 +80,3 @@ Telegram.prototype.log = function (level, msg, meta, callback) {
     callback(null, true);
   });
 };
-
-function format(string) {
-  var args
-  if (arguments.length === 2 && typeof arguments[1] === 'object') {
-    args = arguments[1]
-  } else {
-    args = new Array(arguments.length - 1)
-    for (var i = 1; i < arguments.length; ++i) {
-      args[i - 1] = arguments[i]
-    }
-  }
-  if (!args || !args.hasOwnProperty) {
-    args = {}
-  }
-  return string.replace(nargs, function replaceArg(match, i, index) {
-    var result
-    if (string[index - 1] === '{' &&
-      string[index + match.length] === '}') {
-      return i
-    } else {
-      result = args.hasOwnProperty(i) ? args[i] : null
-      if (result === null || result === undefined) {
-      return ''
-      }
-      return result
-    }
-  })
-}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "bot"
   ],
   "dependencies": {
-    "request": "^2.79.0"
+    "request": "^2.79.0",
+    "sf": "^0.1.8"
   },
   "devDependencies": {
     "winston": "",


### PR DESCRIPTION
I was building an application, i used a lot of meta information with winston and i needed to be able to send that in a message. The built-in format function can't access the property of an object, like: 
```
[{level}] {message}{meta.url} ERROR: {meta.err}
                        ^                 ^
```
so i used the [sf node module](https://github.com/joeferner/node-sf), which is much more powerful and allows much more flexible templates.

I understand this could be a problem if you want to keep dependencies to a minimum, in that case, we could update the built-in format function and use that, but i think we'd end up basically copying the sf module which already does this very well.

By the way, this project has been unbelievably useful, so thanks for creating it!