### PR TITLE
Add batching of messages sent within a certain interval

### DIFF
--- a/lib/winston-telegram.js
+++ b/lib/winston-telegram.js
@@ -11,7 +11,7 @@ var winston = require('winston');
 var format = require('sf');
 
 /**
- * @constructs 
+ * @constructs
  * @param {object} options
  * @param {String} options.token Telegram bot authentication token
  * @param {String} options.chatId Telegram unique identifier for chat
@@ -30,6 +30,10 @@ var Telegram = exports.Telegram = function (options) {
   this.disableNotification = options.disableNotification || false;
   this.name = options.name || this.name;
   this.template = options.template || '[{level}] {message}';
+  this.batchingDelay = options.batchingDelay || 0;
+
+  this.batchedMessages = [];
+  this.batchingTimeout = 0;
 };
 
 /** @extends winston.Transport */
@@ -59,13 +63,44 @@ Telegram.prototype.log = function (level, msg, meta, callback) {
   var self = this;
   if (this.silent) return callback(null, true);
   if (this.unique && this.level != level) return callback(null, true);
-  
+
+  var messageText = format(this.template,{level : level, message : msg, metadata : meta});
+
+  if (this.batchingDelay) {
+    this.batchedMessages.push(messageText);
+
+    if (!this.batchingTimeout) {
+      this.batchingTimeout = setTimeout(function() {
+        var combinedMessages = self.batchedMessages.join("\n\n");
+        self.send(combinedMessages);
+
+        self.batchedMessages = [];
+        self.batchingTimeout = 0;
+      }, this.batchingDelay);
+    }
+  }
+  else {
+    self.send(messageText);
+  }
+
+  callback(null, true);
+};
+
+/**
+ * Actual method that sends the given message to Telegram
+ * @function send
+ * @member Telegram
+ * @param messageText {string} Formatted text to log
+ */
+Telegram.prototype.send = function (messageText) {
+  var self = this;
+
   request({
     url : 'https://api.telegram.org/bot'+this.token+'/sendMessage',
     method : 'POST',
     json : {
       chat_id : this.chatId,
-      text : format(this.template,{level : level, message : msg, metadata : meta}),
+      text : messageText,
       disable_notification : this.disableNotification
     }
   }, function(error, response, body){
@@ -76,6 +111,5 @@ Telegram.prototype.log = function (level, msg, meta, callback) {
       self.emit('error', response.statusCode);
     }
     self.emit('logged');
-    callback(null, true);
   });
-};
+}

--- a/lib/winston-telegram.js
+++ b/lib/winston-telegram.js
@@ -31,6 +31,7 @@ var Telegram = exports.Telegram = function (options) {
   this.name = options.name || this.name;
   this.template = options.template || '[{level}] {message}';
   this.batchingDelay = options.batchingDelay || 0;
+  this.batchingSeparator = options.batchingSeparator || "\n\n";
 
   this.batchedMessages = [];
   this.batchingTimeout = 0;
@@ -71,7 +72,7 @@ Telegram.prototype.log = function (level, msg, meta, callback) {
 
     if (!this.batchingTimeout) {
       this.batchingTimeout = setTimeout(function() {
-        var combinedMessages = self.batchedMessages.join("\n\n");
+        var combinedMessages = self.batchedMessages.join(self.batchingSeparator);
         self.send(combinedMessages);
 
         self.batchedMessages = [];


### PR DESCRIPTION
I was exceeding the rate limit and getting HTTP 429 sent back on start of my application which outputs quite a chunk of messages.

To solve this problem (apart from reducing the number of messages I send out) I implemented batching, which takes all the messages within a certain time interval, combines them and then sends them out as one single message.