### PR TITLE
add error description in case of error

### DIFF
--- a/lib/winston-telegram.js
+++ b/lib/winston-telegram.js
@@ -109,7 +109,7 @@ Telegram.prototype.send = function (messageText) {
       self.emit('error', error);
     }
     if (response && response.statusCode != 200) {
-      self.emit('error', response.statusCode);
+      self.emit('error', response.statusCode + body && body.description && (': ' + body.description) || '');
     }
     self.emit('logged');
   });


### PR DESCRIPTION
in case telegram API server returns an response with an `statusCode !== 200`, add the error description.
This is especially useful for 4xx error codes. See https://core.telegram.org/api/errors