### PR TITLE
Add TransportStreamOption type and send formated message

### DIFF
--- a/lib/winston-telegram.d.ts
+++ b/lib/winston-telegram.d.ts
@@ -32,6 +32,8 @@ declare namespace WinstonTelegram {
     batchingDelay?: number
     /** String with which to join batched messages with (default "\n\n") */
     batchingSeparator?: string
+    /** if set true it use the winston formatter */
+    useWinstonFormatter?: boolean
   }
 
   export interface FormatOptions {

--- a/lib/winston-telegram.d.ts
+++ b/lib/winston-telegram.d.ts
@@ -1,7 +1,7 @@
-import TransportStream from "winston-transport"
+import TransportStream, { TransportStreamOptions } from 'winston-transport'
 
 declare class WinstonTelegram extends TransportStream {
-  constructor(options: WinstonTelegram.Options)
+  constructor(options: WinstonTelegram.Options & TransportStreamOptions)
 }
 
 declare namespace WinstonTelegram {
@@ -33,13 +33,12 @@ declare namespace WinstonTelegram {
     /** String with which to join batched messages with (default "\n\n") */
     batchingSeparator?: string
   }
-  
+
   export interface FormatOptions {
-    level: string,
-    message: string,
+    level: string
+    message: string
     metadata: any
   }
-
 }
 
 export default WinstonTelegram

--- a/lib/winston-telegram.js
+++ b/lib/winston-telegram.js
@@ -54,6 +54,7 @@ module.exports = class Telegram extends Transport {
     this.batchingSeparator = options.batchingSeparator || '\n\n'
     this.batchedMessages = []
     this.batchingTimeout = 0
+    this.useWinstonFormatter = options.useWinstonFormatter || false
   }
 
   /**
@@ -75,12 +76,12 @@ module.exports = class Telegram extends Transport {
       metadata: info.metadata
     }
 
-    if (this.formatMessage) {
+    if (this.format || this.useWinstonFormatter) {
+      messageText = info[MESSAGE]
+    } else if (this.formatMessage) {
       messageText = this.formatMessage(formatOptions)
-    } else if (this.template) {
-      messageText = format(this.template, formatOptions)
     } else {
-      messageText = this.info[MESSAGE]
+      messageText = format(this.template, formatOptions)
     }
 
     if (this.batchingDelay) {

--- a/lib/winston-telegram.js
+++ b/lib/winston-telegram.js
@@ -8,6 +8,7 @@
 const https = require('https')
 const format = require('sf')
 const Transport = require('winston-transport')
+const { MESSAGE } = require('triple-beam')
 
 /**
  * @constructs
@@ -76,8 +77,10 @@ module.exports = class Telegram extends Transport {
 
     if (this.formatMessage) {
       messageText = this.formatMessage(formatOptions)
-    } else {
+    } else if (this.template) {
       messageText = format(this.template, formatOptions)
+    } else {
+      messageText = this.info[MESSAGE]
     }
 
     if (this.batchingDelay) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "dependencies": {
     "sf": "^0.2.0",
+    "triple-beam": "^1.3.0",
     "winston-transport": "^4.3.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
with this pull request you can create `TelegramTransport` with transport stream option type,
also when `format` or `useWinstonLogger` is set it will send the formatted message create by `winston.formatter` to telegra.