### PR TITLE
Azliabdullah patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Documentation below is for `winston-telegram@3`. [Read the `winston-telegram@1.x
 const logger = require('winston')
 const TelegramLogger = require('winston-telegram')
 
+// or
+import * as TelegramLogger from 'winston-telegram';
+
 logger.add(new TelegramLogger(options))
 ```
 

--- a/lib/winston-telegram.d.ts
+++ b/lib/winston-telegram.d.ts
@@ -42,4 +42,4 @@ declare namespace WinstonTelegram {
 
 }
 
-export default WinstonTelegram
+export = WinstonTelegram


### PR DESCRIPTION
fixed `winston_telegram_1.default is not a constructor` issue in Typescript and able to import via
`import * as TelegramLogger from 'winston-telegram';`